### PR TITLE
Cosmetic changes to example commands, switches, etc

### DIFF
--- a/RECmd/Program.cs
+++ b/RECmd/Program.cs
@@ -79,9 +79,7 @@ internal class Program
 
     private static readonly string Footer = @"Example: RECmd.exe --f ""C:\Temp\UsrClass 1.dat"" --sk URL --recover false --nl" +
                                             "\r\n\t " +
-                                            @"    RECmd.exe --f ""D:\temp\UsrClass 1.dat"" --StartDate ""11/13/2014 15:35:01"" " +
-                                            "\r\n\t " +
-                                            @"    RECmd.exe --f ""D:\temp\UsrClass 1.dat"" --RegEx --sv ""(App|Display)Name""";
+                                           @"    RECmd.exe --f ""D:\temp\UsrClass 1.dat"" --RegEx --sv ""(App|Display)Name""";
 
     private static readonly HashSet<string> _seenHashes = new();
 

--- a/RECmd/Program.cs
+++ b/RECmd/Program.cs
@@ -189,6 +189,7 @@ internal class Program
             new Option<int>(
                 "--base64",
                 "Find Base64 encoded values with size >= Base64 (specified in bytes)"),
+
             new Option<int>(
                 "--minSize",
                 "Find values with data size >= MinSize (specified in bytes)"),
@@ -196,15 +197,19 @@ internal class Program
             new Option<string>(
                 "--sa",
                 "Search for <string> in keys, values, data, and slack"),
+
             new Option<string>(
                 "--sk",
                 "Search for <string> in value record's key names"),
+
             new Option<string>(
                 "--sv",
                 "Search for <string> in value record's value names"),
+
             new Option<string>(
                 "--sd",
                 "Search for <string> in value record's value data"),
+
             new Option<string>(
                 "--ss",
                 "Search for <string> in value record's value slack"),

--- a/RECmd/Program.cs
+++ b/RECmd/Program.cs
@@ -79,7 +79,7 @@ internal class Program
 
     private static readonly string Footer = @"Example: RECmd.exe --f ""C:\Temp\UsrClass 1.dat"" --sk URL --recover false --nl" +
                                             "\r\n\t " +
-                                           @"    RECmd.exe --f ""D:\temp\UsrClass 1.dat"" --RegEx --sv ""(App|Display)Name""";
+                                           @"    RECmd.exe --f ""D:\temp\UsrClass 1.dat"" --regex --sv ""(App|Display)Name""";
 
     private static readonly HashSet<string> _seenHashes = new();
 


### PR DESCRIPTION
## Description

remove command example that had a non-existent switch, adjust capitalization of one of the examples, and adjust spacing between the switches to be more consistent