### PR TITLE
Change Readme to refer to DFIRBatch instead of Kroll_Batch

### DIFF
--- a/BatchExamples/README.md
+++ b/BatchExamples/README.md
@@ -3,7 +3,7 @@
 
 RECmd uses Batch Files (`.reb` file extension) as a means to filter out potentially irrelevant information from the Windows Registry. There is an incredible amount of data stored within the Windows Registry, but much of it is not human readable or useful to an examiner. Batch Files attempt to provide the most high fidelity information and present them in an easy to digest format. 
 
-As of 2021, the [Kroll Batch File](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/Kroll_Batch.reb) is the most frequently maintained Batch File. It serves as the default Registry output for KAPE's [!EZParser](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/!EZParser.mkape) Module. This Batch File has been curated to take advantage of most, if not all, available [Registry Plugins](https://github.com/EricZimmerman/RegistryPlugins).
+As of 2024, the [DFIR Batch File](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/DFIRBatch.reb) is the most frequently maintained Batch File. It serves as the default Registry output for KAPE's [!EZParser](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/!EZParser.mkape) Module. This Batch File has been curated to take advantage of most, if not all, available [Registry Plugins](https://github.com/EricZimmerman/RegistryPlugins).
 
 ## Disclaimer
 

--- a/BatchExamples/README.md
+++ b/BatchExamples/README.md
@@ -3,7 +3,7 @@
 
 RECmd uses Batch Files (`.reb` file extension) as a means to filter out potentially irrelevant information from the Windows Registry. There is an incredible amount of data stored within the Windows Registry, but much of it is not human readable or useful to an examiner. Batch Files attempt to provide the most high fidelity information and present them in an easy to digest format. 
 
-As of 2024, the [DFIR Batch File](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/DFIRBatch.reb) is the most frequently maintained Batch File. It serves as the default Registry output for KAPE's [!EZParser](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/!EZParser.mkape) Module. This Batch File has been curated to take advantage of most, if not all, available [Registry Plugins](https://github.com/EricZimmerman/RegistryPlugins).
+As of 2024, the [DFIR Batch File](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/DFIRBatch.reb) is the most frequently maintained Batch File. It serves as the default Registry output for KAPE's [!EZParser](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/Compound/!EZParser.mkape) Module. This Batch File has been curated to take advantage of most, if not all, available [Registry Plugins](https://github.com/EricZimmerman/RegistryPlugins).
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Ongoing Projects
 
- * [Kroll Batch File](https://github.com/EricZimmerman/RECmd/projects/1) - Development roadmap for the [Kroll Batch File](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/Kroll_Batch.reb). Please feel free to contribute by adding ideas or by finishing tasks in the `To Do` column. Any help is appreciated! 
+ * [DFIR Batch File (Formally Kroll Batch)](https://github.com/EricZimmerman/RECmd/projects/1) - Development roadmap for the [DFIR Batch File](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/DFIRBatch.reb). Please feel free to contribute by adding ideas or by finishing tasks in the `To Do` column. Any help is appreciated! 
 
 ## Command Line Interface
 
@@ -73,7 +73,7 @@ PS> Unblock-File .\Plugins\*.dll
 
 RECmd uses Batch Files to make your Registry output more actionable. Learn about Batch Files [here](https://github.com/EricZimmerman/RECmd/tree/master/BatchExamples#readme)!
 
-As of September 2021, there is a README specifically for the Kroll_Batch file used by RECmd and KAPE. Find it [here](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/Kroll_Batch.md)!
+As of May 2024, there is a README specifically for the DFIRBatch file used by RECmd and KAPE. Find it [here](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/DFIRBatch.md)!
 
 # RLA
 


### PR DESCRIPTION
## Description

Change Readme to refer to DFIRBatch instead of Kroll_Batch to avoid confusion. I recommend to change the project/ development roadmap board name as well.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

<strike> - [ ] I have generated a unique `GUID` for my Batch file(s) </strike>
<strike> - [ ] I have tested and validated the new Batch file(s) against test data and achieved the desired output </strike>
<strike> - [ ] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory </strike>
<strike> - [ ] I have set or updated the version of my Batch file(s) </strike>
<strike> - [ ] I have made an attempt to document the artifacts within the Batch file(s) </strike>
<strike> - [ ] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format </strike>

Thank you for your submission and for contributing to the DFIR community!
