### PR TITLE
Update DFIRBatch - Fix Windows Defender Comment for SubmitSamplesConsent

### DIFF
--- a/BatchExamples/DFIRBatch.md
+++ b/BatchExamples/DFIRBatch.md
@@ -47,6 +47,7 @@ Example entry, please follow this format:
 | 1.22 | 2023-06-20 | Added new Windows 11 artifact - RunNotification [Autoruns], fix minor spelling errors |
 | 2.00 | 2024-05-18 | Renamed from Kroll_Batch to DFIRBatch. This was done to ensure examiners or companies that aren't Kroll felt comfortable using this Batch file without any fear for license violation, competitor affiliation, etc. This Batch file will be maintained primarily moving forward |
 | 2.01 | 2024-07-03 | Added Citrix artifacts |
+| 2.02 | 2024-08-04 | Fix Windows Defender Comment for SubmitSamplesConsent |
 
 # Documentation
 

--- a/BatchExamples/DFIRBatch.reb
+++ b/BatchExamples/DFIRBatch.reb
@@ -1,6 +1,6 @@
 Description: DFIR RECmd Batch File
 Author: Andrew Rathbun
-Version: 2.01
+Version: 2.02
 Id: ecc582d5-a1b1-4256-ae64-ca2263b8f972
 Keys:
 #
@@ -3207,9 +3207,10 @@ Keys:
         KeyPath: Microsoft\Windows Defender\SpyNet
         ValueName: SubmitSamplesConsent
         Recursive: false
-        Comment: "Windows Defender SubmitSamplesConsent Status, 0 = Disabled, 1 = Enabled"
+        Comment: "Windows Defender SubmitSamplesConsent Status, 0 = Always prompt, 1 = Send safe samples automatically, 2 = Never send, 3 = Send all samples automatically"
 
 # https://gist.github.com/MHaggis/a955f1351a7d07592b90ab605e3b02d9
+# https://learn.microsoft.com/en-us/powershell/module/defender/set-mppreference?view=windowsserver2022-ps#-submitsamplesconsent
 
     -
         Description: PortProxy Configuration


### PR DESCRIPTION
## Description

On a recent case I was on a threat actor set the value of this registry key to 2 which when I verified what it meant on Microsoft Learn was Never Send (Disable) instead of 0. 

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Batch file(s)
- [X] I have tested and validated the new Batch file(s) against test data and achieved the desired output
- [X] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory
- [X] I have set or updated the version of my Batch file(s)
- [X] I have made an attempt to document the artifacts within the Batch file(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
