### PR TITLE
Add SYSTEMTIME Support to BinConvert

### DIFF
--- a/RECmd/Program.cs
+++ b/RECmd/Program.cs
@@ -2334,7 +2334,31 @@ internal class Program
                             rebOut.ValueData = regVal.ValueData;
                         }
 
-                        break;
+                         break;
+                    case Key.BinConvert.Systemtime:
+                        try
+                        {
+                            int index = 0;
+                            int int16_1 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, index);
+                            int int16_2 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 2 + index);
+                            int int16_3 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 4 + index);
+                            int int16_4 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 6 + index);
+                            int int16_5 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 8 + index);
+                            int int16_6 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 10 + index);
+                            int int16_7 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 12 + index);
+                            int int16_8 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 14 + index);
+
+                            var st = new DateTimeOffset(new DateTime(int16_1, int16_2, int16_4, int16_5, int16_6, int16_7, int16_8, DateTimeKind.Utc)).ToUniversalTime().ToString();
+                            rebOut.ValueData = st;
+
+                        }
+                        catch (Exception)
+                        {
+                            Log.Warning("Error converting to SYSTEMTIME. Using bytes instead!");
+                            rebOut.ValueData = regVal.ValueData;
+                        }
+
+						break;
                     default:
                         rebOut.ValueData = regVal.ValueData;
                         break;
@@ -2372,6 +2396,31 @@ internal class Program
                     catch (Exception)
                     {
                         Log.Warning("Error converting to FILETIME. Using bytes instead!");
+                        rebOut.ValueData = regVal.ValueData;
+                    }
+                   
+                   break;
+                
+                case Key.BinConvert.Systemtime:
+                    try
+                    {
+                        int index = 0;
+                        int int16_1 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, index);
+                        int int16_2 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 2 + index);
+                        int int16_3 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 4 + index);
+                        int int16_4 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 6 + index);
+                        int int16_5 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 8 + index);
+                        int int16_6 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 10 + index);
+                        int int16_7 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 12 + index);
+                        int int16_8 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 14 + index);
+
+                        var st = new DateTimeOffset(new DateTime(int16_1, int16_2, int16_4, int16_5, int16_6, int16_7, int16_8, DateTimeKind.Utc)).ToUniversalTime().ToString();
+                        rebOut.ValueData = st;
+
+                    }
+                    catch (Exception)
+                    {
+                        Log.Warning("Error converting to SYSTEMTIME. Using bytes instead!");
                         rebOut.ValueData = regVal.ValueData;
                     }
 

--- a/RECmd/ReBatch.cs
+++ b/RECmd/ReBatch.cs
@@ -29,7 +29,8 @@ public class Key
         Filetime = 1,
         [Description("IPv4 address")] Ip = 2,
         [Description("DWord to Epoch")] Epoch = 3,
-        [Description("Binary to SID")] Sid = 4
+        [Description("Binary to SID")] Sid = 4,
+        [Description("128 bit Windows SYSTEMTIME")] Systemtime = 5
     }
 
     public enum HiveType_


### PR DESCRIPTION
## Description

I added the ability to convert Registry Key Values to SYSTEMTIME. This is based off the code I borrowed from the Data Interpreter in Registry Explorer with minor edits (I figured if it works why reinvent the wheel). This is needed so I can add LogonStats to DFIRBatch. Below is a preview of it working.

![image](https://github.com/user-attachments/assets/35b2ecd3-b930-4491-85ec-9fc881c2ba7d)

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Batch file(s)
- [X] I have tested and validated the new Batch file(s) against test data and achieved the desired output
- [X] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory
- [X] I have set or updated the version of my Batch file(s)
- [X] I have made an attempt to document the artifacts within the Batch file(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
