### PR TITLE
Add Support for DEFAULT Registry Hive

### DIFF
--- a/RECmd/Program.cs
+++ b/RECmd/Program.cs
@@ -505,6 +505,7 @@ internal class Program
             okFileParts.Add("SECURITY");
             okFileParts.Add("DRIVERS");
             okFileParts.Add("COMPONENTS");
+            okFileParts.Add("DEFAULT");
 
             IEnumerable<string> files2;
 
@@ -640,6 +641,7 @@ internal class Program
                 "*SYSTEM",
                 "*SAM",
                 "*SOFTWARE",
+                "*DEFAULT",
                 "*AMCACHE.HVE",
                 "*SYSCACHE.hve",
                 "*SECURITY",


### PR DESCRIPTION
## Description

RECmd does not process the DEFAULT Registry hive when using the -d option. As a result we cannot use it for the Batch Files currently when using KAPE. This adds support which will allow us to create rules for systemprofile. Below is an example of WinSCP being installed as the SYSTEM user and a rule using the DEFAULT Registry hive successfully with the changes.

![image](https://github.com/user-attachments/assets/06409782-c2bb-49ea-ad39-2584bdbb0872)


## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

~~- [X] I have generated a unique `GUID` for my Batch file(s)~~
~~- [X] I have tested and validated the new Batch file(s) against test data and achieved the desired output~~
~~- [X] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory~~
~~- [X] I have set or updated the version of my Batch file(s)~~
~~- [X] I have made an attempt to document the artifacts within the Batch file(s)~~
~~- [X] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format~~

Thank you for your submission and for contributing to the DFIR community!
