### PR TITLE
Change default behaviour of nl true

### DIFF
--- a/RECmd/Program.cs
+++ b/RECmd/Program.cs
@@ -237,7 +237,7 @@ internal class Program
             new Option<bool>(
                 "--nl",
                 () => false,
-                "When true, ignore transaction log files for dirty hives"),
+                "When true, allow transaction log files to not exist for dirty hives"),
 
             new Option<bool>(
                 "--recover",
@@ -886,8 +886,6 @@ internal class Program
                     }
                     else
                     {
-                        if (nl == false)
-                        {
                             if (rawFiles != null)
                             {
                                 var lt = new List<TransactionLogFileInfo>();
@@ -905,11 +903,6 @@ internal class Program
                             {
                                 reg.ProcessTransactionLogs(logFiles.ToList(), true);
                             }
-                        }
-                        else
-                        {
-                            Log.Warning("Registry hive is dirty and transaction logs were found in the same directory, but --nl was provided. Data may be missing! Continuing anyways...");
-                        }
                     }
                 }
                 


### PR DESCRIPTION
## Description

This Pull Request changes the default behaviour when the flag nl is set to false. Before the commit if there are no transaction logs and it detects a dirty registry hive it aborts. This commit logs a warning to the console instead of aborting the processing of a dirty hive. In some cases triage tools either fail to pick up the transaction logs or the transaction logs have been erased from disk via anti-forensics techniques. Currently if this is the case and the registry is dirty they are not processed leading to certain hives not showing up on DFIRBatch. 

I have had this happen on several cases and I believe that it is better to have some visibility rather than entire users/ hives being absent. An example of this happening was one of the compromised users on a case had a dirty registry hive with no transaction logs and within the hive was WinSCP registry keys showing the exfiltration IP address and protocol used to exfiltrate. 

I am aware of nl true existing however this means that all transaction logs are ignored even if it exists for some users/hives and I would like the ability to process the transaction logs if they are present. I am willing to discuss this and put it under a separate argument if you believe this is not a sane default to have.

Edit: Changed based on feedback by Eric to modify nl true instead

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

~~- [X] I have generated a unique `GUID` for my Batch file(s)~~
~~- [X] I have tested and validated the new Batch file(s) against test data and achieved the desired output~~
~~- [X] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory~~
~~- [X] I have set or updated the version of my Batch file(s)~~
~~- [X] I have made an attempt to document the artifacts within the Batch file(s)~~
~~- [X] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format~~

Thank you for your submission and for contributing to the DFIR community!
