### PR TITLE
Add Angry IP Scanner to DFIRBatch

### DIFF
--- a/BatchExamples/DFIRBatch.md
+++ b/BatchExamples/DFIRBatch.md
@@ -55,6 +55,7 @@ Example entry, please follow this format:
 | 2.06 | 2024-09-06 | Added various JPCert artifacts around remote access tools, Added LogonStats and an example of DEFAULT registry hive use with WinSCP  |
 | 2.07 | 2024-11-26 | Added new artifacts from the DEFAULT registry hive  |
 | 2.08 | 2024-12-07 | Added WinSCP DEFAULT artifact back and added Advanced IP Scanner and Advanced Port Scanner Artifacts |
+| 2.09 | 2024-12-19 | Added Angry IP Scanner Artifacts |
 
 # Documentation
 

--- a/BatchExamples/DFIRBatch.reb
+++ b/BatchExamples/DFIRBatch.reb
@@ -1,6 +1,6 @@
 Description: DFIR RECmd Batch File
 Author: Andrew Rathbun
-Version: 2.08
+Version: 2.09
 Id: 2e1589f5-e31a-4bef-822f-075d56afdddd
 Keys:
 #
@@ -2964,6 +2964,40 @@ Keys:
         KeyPath: Software\Famatech\advanced_ip_scanner
         Recursive: true
         Comment: "Displays artifacts relating to Advanced IP Scanner"
+
+# Third Party Applications -> Angry IP Scanner - https://angryip.org/
+
+    -
+        Description: Angry IP Scanner - Legacy
+        HiveType: NTUSER
+        Category: Third Party Applications
+        KeyPath: Software\Angryziber\ipscan
+        Recursive: true
+        Comment: "Displays artifacts relating to Angry IP Scanner"
+
+    -
+        Description: Angry IP Scanner - Legacy
+        HiveType: DEFAULT
+        Category: Third Party Applications
+        KeyPath: Software\Angryziber\ipscan
+        Recursive: true
+        Comment: "Displays artifacts relating to Angry IP Scanner"
+
+    -
+        Description: Angry IP Scanner
+        HiveType: NTUSER
+        Category: Third Party Applications
+        KeyPath: Software\JavaSoft\Prefs\ipscan
+        Recursive: true
+        Comment: "Displays artifacts relating to Angry IP Scanner"
+
+    -
+        Description: Angry IP Scanner
+        HiveType: DEFAULT
+        Category: Third Party Applications
+        KeyPath: Software\JavaSoft\Prefs\ipscan
+        Recursive: true
+        Comment: "Displays artifacts relating to Angry IP Scanner"
 
 # --------------------
 # CLOUD STORAGE


### PR DESCRIPTION
## Description

Apologies for the volume of these PRs @AndrewRathbun. This follows on from #84 and adds Angry IP Scanner to DFIRBatch. As usual both SYSTEM user and standard user were tested with these. I also added the legacy version but that one isn't as useful as it seems you have to click an option to save the settings to registry during my testing rather than them being automatically created like the current version. 

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Batch file(s)
- [X] I have tested and validated the new Batch file(s) against test data and achieved the desired output
- [X] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory
- [X] I have set or updated the version of my Batch file(s)
- [X] I have made an attempt to document the artifacts within the Batch file(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
