### PR TITLE
Update BatchCsvOut.cs

### DIFF
--- a/RECmd/BatchCsvOut.cs
+++ b/RECmd/BatchCsvOut.cs
@@ -1,27 +1,53 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 
-namespace RECmd;
-
-public class BatchCsvOut
+namespace RECmd
 {
-    public string HivePath { get; set; }
-    public string HiveType { get; set; }
-    public string Description { get; set; }
-    public string Category { get; set; }
-    public string KeyPath { get; set; }
-    public string ValueName { get; set; }
+    public class BatchCsvOut
+    {
+        public string HivePath { get; set; }
+        public string HiveType { get; set; }
+        public string Description { get; set; }
+        public string Category { get; set; }
+        public string KeyPath { get; set; }
+        public string ValueName { get; set; }
 
-    public string ValueType { get; set; }
-    public string ValueData { get; set; }
-    public string ValueData2 { get; set; }
-    public string ValueData3 { get; set; }
+        public string ValueType { get; set; }
+        public string ValueData { get; set; }
+        public string ValueData2 { get; set; }
+        public string ValueData3 { get; set; }
 
-    public string Comment { get; set; }
-    public bool Recursive { get; set; }
-    public bool Deleted { get; set; }
+        public string Comment { get; set; }
+        public bool Recursive { get; set; }
+        public bool Deleted { get; set; }
 
+        public DateTimeOffset? LastWriteTimestamp { get; set; }
 
-    public DateTimeOffset? LastWriteTimestamp { get; set; }
+        public string PluginDetailFile { get; set; }
 
-    public string PluginDetailFile { get; set; }
+        // Method to format the LastWriteTimestamp
+        public string GetFormattedTimestamp()
+        {
+            string dateTimeFormat = "yyyy-MM-dd HH:mm:ss.fffffff";
+            return LastWriteTimestamp?.ToString(dateTimeFormat, CultureInfo.InvariantCulture) ?? string.Empty;
+        }
+
+        // Method to write the CSV
+        public static void WriteCsv(string filePath, List<BatchCsvOut> data)
+        {
+            using (StreamWriter writer = new StreamWriter(filePath))
+            {
+                // Write CSV header
+                writer.WriteLine("HivePath,HiveType,Description,Category,KeyPath,ValueName,ValueType,ValueData,ValueData2,ValueData3,Comment,Recursive,Deleted,LastWriteTimestamp,PluginDetailFile");
+
+                // Write CSV rows
+                foreach (var item in data)
+                {
+                    writer.WriteLine($"{item.HivePath},{item.HiveType},{item.Description},{item.Category},{item.KeyPath},{item.ValueName},{item.ValueType},{item.ValueData},{item.ValueData2},{item.ValueData3},{item.Comment},{item.Recursive},{item.Deleted},{item.GetFormattedTimestamp()},{item.PluginDetailFile}");
+                }
+            }
+        }
+    }
 }

--- a/RECmd/BatchCsvOut.cs
+++ b/RECmd/BatchCsvOut.cs
@@ -27,16 +27,10 @@ namespace RECmd
 
         public string PluginDetailFile { get; set; }
 
-        // Method to format the LastWriteTimestamp
-        public string GetFormattedTimestamp()
-        {
-            string dateTimeFormat = "yyyy-MM-dd HH:mm:ss.fffffff";
-            return LastWriteTimestamp?.ToString(dateTimeFormat, CultureInfo.InvariantCulture) ?? string.Empty;
-        }
-
         // Method to write the CSV
         public static void WriteCsv(string filePath, List<BatchCsvOut> data)
         {
+            string dateTimeFormat = "yyyy-MM-dd HH:mm:ss.fffffff";
             using (StreamWriter writer = new StreamWriter(filePath))
             {
                 // Write CSV header
@@ -45,7 +39,8 @@ namespace RECmd
                 // Write CSV rows
                 foreach (var item in data)
                 {
-                    writer.WriteLine($"{item.HivePath},{item.HiveType},{item.Description},{item.Category},{item.KeyPath},{item.ValueName},{item.ValueType},{item.ValueData},{item.ValueData2},{item.ValueData3},{item.Comment},{item.Recursive},{item.Deleted},{item.GetFormattedTimestamp()},{item.PluginDetailFile}");
+                    string formattedTimestamp = item.LastWriteTimestamp?.ToString(dateTimeFormat, CultureInfo.InvariantCulture) ?? string.Empty;
+                    writer.WriteLine($"{item.HivePath},{item.HiveType},{item.Description},{item.Category},{item.KeyPath},{item.ValueName},{item.ValueType},{item.ValueData},{item.ValueData2},{item.ValueData3},{item.Comment},{item.Recursive},{item.Deleted},{formattedTimestamp},{item.PluginDetailFile}");
                 }
             }
         }


### PR DESCRIPTION
Proposed we modify the BatchCsvOut class to output the LastWriteTimestamp in the format yyyy-MM-dd HH:mm:ss.fffffff. 

- Create a method GetFormattedTimestamp that formats the LastWriteTimestamp property.

- Use the GetFormattedTimestamp method when writing the CSV file.

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have generated a unique `GUID` for my Batch file(s)
- [ ] I have tested and validated the new Batch file(s) against test data and achieved the desired output
- [ ] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory
- [ ] I have set or updated the version of my Batch file(s)
- [ ] I have made an attempt to document the artifacts within the Batch file(s)
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
