### PR TITLE
Bugfix to prevent duplicate entries for NTUSER.DAT

### DIFF
--- a/RECmd/Program.cs
+++ b/RECmd/Program.cs
@@ -506,10 +506,10 @@ internal class Program
             okFileParts.Add("DRIVERS");
             okFileParts.Add("COMPONENTS");
             okFileParts.Add("DEFAULT");
-            okFileParts.Add("User");
-            okFileParts.Add("UserClasses");
-            okFileParts.Add("settings");
-            okFileParts.Add("Registry");
+            okFileParts.Add("USER");
+            okFileParts.Add("USERCLASSES");
+            okFileParts.Add("SETTINGS");
+            okFileParts.Add("REGISTRY");
 
             IEnumerable<string> files2;
 


### PR DESCRIPTION
## Description

Made an oopsie when putting in user.dat support. On .NET6/9 it acts differently than what is in .NET4 and I assumed it was the same behaviour across both. Doing it this way prevents NTUSER .dat entries showing up twice. i.e. once for it hitting on NTUSER .dat and once for hitting the user.dat mask as well.

Sorry for this!
