### PR TITLE
Added Initial User.dat Windows Store UWP and WinSCP Windows Store Artifacts

### DIFF
--- a/BatchExamples/DFIRBatch.md
+++ b/BatchExamples/DFIRBatch.md
@@ -9,6 +9,7 @@ Special thanks to those who have contributed to this Batch file:
 * Chris Kudless
 * [Reece394](https://github.com/reece394)
 * [esecrpm](https://github.com/esecrpm)
+* [ogmini](https://github.com/ogmini)
 
 # Version History
 
@@ -62,6 +63,7 @@ Example entry, please follow this format:
 | 2.12 | 2025-07-01 | Added MobaXTerm artifacts [Third Party Applications] |
 | 2.13 | 2025-07-01 | Added User Account Control Artifacts |
 | 2.14 | 2025-07-05 | Added System Info, Processor Info, Recent File List and Registry Editor Usage Artifacts |
+| 2.15 | 2025-07-12 | Added Initial User.dat Windows Store UWP and WinSCP Windows Store Artifacts |
 
 # Documentation
 

--- a/BatchExamples/DFIRBatch.reb
+++ b/BatchExamples/DFIRBatch.reb
@@ -1,6 +1,6 @@
 Description: DFIR RECmd Batch File
 Author: Andrew Rathbun
-Version: 2.14
+Version: 2.15
 Id: 6e68cc0b-c945-428b-ab91-c02d91c877b8
 Keys:
 #
@@ -1574,6 +1574,13 @@ Keys:
         KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\MountPoints2
         Recursive: true
         Comment: "Mount Points - NTUSER"
+    -
+        Description: MountPoints2
+        HiveType: User
+        Category: Devices
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\MountPoints2
+        Recursive: true
+        Comment: "Mount Points - User.dat Windows Store UWP"
 
 # https://www.sans.org/security-resources/posters/windows-forensic-analysis/170/download
 # https://eforensicsmag.com/investigating-usb-drives-using-mount-points-not-drive-letters-by-ali-hadi/
@@ -1838,6 +1845,13 @@ Keys:
         KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\CIDSizeMRU
         Recursive: false
         Comment: "Recently ran applications, lower MRU # (Value Data3) = more recent"
+    -
+        Description: CIDSizeMRU
+        HiveType: User
+        Category: Program Execution
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\CIDSizeMRU
+        Recursive: false
+        Comment: "Recently ran applications, lower MRU # (Value Data3) = more recent - Windows Store UWP"
 
 # CIDSizeMRU plugin - https://github.com/EricZimmerman/RegistryPlugins/tree/master/RegistryPlugin.CIDSizeMRU
 # https://windowsir.blogspot.com/2013/07/howto-determine-user-access-to-files.html
@@ -1887,6 +1901,13 @@ Keys:
         KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\UserAssist\*\Count
         Recursive: false
         Comment: "GUI-based programs launched from the desktop"
+    -
+        Description: UserAssist
+        HiveType: User
+        Category: Program Execution
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\UserAssist\*\Count
+        Recursive: false
+        Comment: "GUI-based programs launched from the desktop - Windows Store UWP"
 
 # UserAssist plugin - https://github.com/EricZimmerman/RegistryPlugins/tree/master/RegistryPlugin.UserAssist
 # https://www.sans.org/security-resources/posters/windows-forensic-analysis/170/download
@@ -1980,6 +2001,13 @@ Keys:
         KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\TypedPaths
         Recursive: false
         Comment: "Displays paths that were typed by the user in Windows Explorer"
+    -
+        Description: TypedPaths
+        HiveType: User
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\TypedPaths
+        Recursive: false
+        Comment: "Displays paths that were typed by the user in Windows Explorer - Windows Store UWP"
 
 # https://www.hecfblog.com/2018/09/daily-blog-483-typed-paths-amnesia.html
 # http://windowsir.blogspot.com/2013/07/howto-determine-user-access-to-files.html
@@ -2020,6 +2048,13 @@ Keys:
         KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\WordWheelQuery
         Recursive: true
         Comment: "User Searches"
+    -
+        Description: WordWheelQuery
+        HiveType: User
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\WordWheelQuery
+        Recursive: true
+        Comment: "User Searches - Windows Store UWP"
 
 # https://www.sans.org/security-resources/posters/windows-forensic-analysis/170/download
 # https://tzworks.net/prototype_page.php?proto_id=19
@@ -2044,6 +2079,13 @@ Keys:
         KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\OpenSavePidlMRU
         Recursive: false
         Comment: "Tracks files that have been opened or saved within a Windows shell dialog box"
+    -
+        Description: OpenSavePidlMRU
+        HiveType: User
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\OpenSavePidlMRU
+        Recursive: false
+        Comment: "Tracks files that have been opened or saved within a Windows shell dialog box - Windows Store UWP"
 
 # OpenSavePidlMRU plugin - https://github.com/EricZimmerman/RegistryPlugins/tree/master/RegistryPlugin.OpenSavePidlMRU
 # https://www.sans.org/blog/opensavemru-and-lastvisitedmru/
@@ -2065,6 +2107,13 @@ Keys:
         KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\LastVisitedPidlMRU
         Recursive: false
         Comment: "Tracks the specific executable used by an application to open the files documented in OpenSavePidlMRU"
+    -
+        Description: LastVisitedPidlMRU
+        HiveType: User
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\ComDlg32\LastVisitedPidlMRU
+        Recursive: false
+        Comment: "Tracks the specific executable used by an application to open the files documented in OpenSavePidlMRU - Windows Store UWP"
 
 # LastVisitedPidlMRU plugin - https://github.com/EricZimmerman/RegistryPlugins/tree/master/RegistryPlugin.LastVisitedPidlMRU
 # https://www.sans.org/blog/opensavemru-and-lastvisitedmru
@@ -2095,6 +2144,13 @@ Keys:
         KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\RecentDocs
         Recursive: true
         Comment: "Files recently opened from Windows Explorer"
+    -
+        Description: RecentDocs
+        HiveType: User
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\RecentDocs
+        Recursive: true
+        Comment: "Files recently opened from Windows Explorer - Windows Store UWP"
 
 # RecentDocs plugin - https://github.com/EricZimmerman/RegistryPlugins/tree/master/RegistryPlugin.RecentDocs
 # https://forensic4cast.com/2019/03/the-recentdocs-key-in-windows-10/
@@ -2119,6 +2175,17 @@ Keys:
         Comment: "Displays recent files accessed by the user with MS Paint"
 
 # https://forensafe.com/blogs/PaintMRU.html
+
+    -
+        Description: Recent File List
+        HiveType: User
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Applets\Paint\Recent File List
+        Recursive: false
+        Comment: "Displays recent files accessed by the user with MS Paint Windows Store Version"
+
+# https://forensafe.com/blogs/PaintMRU.html
+# https://ogmini.github.io/2025/06/14/Microsoft-Paint-Application-Hive.html
 
     -
         Description: Recent File List
@@ -2857,6 +2924,13 @@ Keys:
         KeyPath: Software\Martin Prikryl
         Recursive: true
         Comment: "WinSCP"
+    -
+        Description: WinSCP
+        HiveType: User
+        Category: Third Party Applications
+        KeyPath: Software\Martin Prikryl
+        Recursive: true
+        Comment: "WinSCP Windows Store Version"
 
 # Third Party Applications -> Ares - https://www.ares.net/
 
@@ -3627,6 +3701,13 @@ Keys:
         KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts
         Recursive: false
         Comment: "Tracks programs associated with file extensions"
+    -
+        Description: File Extensions
+        HiveType: User
+        Category: Installed Software
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts
+        Recursive: false
+        Comment: "Tracks programs associated with file extensions - Windows Store UWP"
 
 # FileExts plugin - https://github.com/EricZimmerman/RegistryPlugins/tree/master/RegistryPlugin.FileExts
 # https://www.marshall.edu/forensics/files/Brewer-PosterFinal.pdf


### PR DESCRIPTION
## Description

This adds a bunch of registry keys that have been observed being written to User.dat Windows Store apps. These have been verified by already in use systems or generating test data. Thankfully Microsoft has been lazy and not modified the key locations meaning all RegistryPlugins work without edits. 

This covers:
MountPoints2
CIDSizeMRU
OpenSavePidlMRU
LastVisitedPidlMRU
UserAssist
TypedPaths
WordWheelQuery
RecentDocs
Paint Recent File List
FileExts

I also as per tradition tested the WinSCP Windows Store app and verified the key paths are the same as well. 

This supersedes #90. Thanks @ogmini for the original commit. I made sure to credit you for your research and work put into this already.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Batch file(s)
- [X] I have tested and validated the new Batch file(s) against test data and achieved the desired output
- [X] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory
- [X] I have set or updated the version of my Batch file(s)
- [X] I have made an attempt to document the artifacts within the Batch file(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
