### PR TITLE
Added ApplicationAssociationToasts and More Office MRU Artifacts

### DIFF
--- a/BatchExamples/DFIRBatch.md
+++ b/BatchExamples/DFIRBatch.md
@@ -65,6 +65,7 @@ Example entry, please follow this format:
 | 2.14 | 2025-07-05 | Added System Info, Processor Info, Recent File List and Registry Editor Usage Artifacts |
 | 2.15 | 2025-07-12 | Added Initial User.dat Windows Store UWP and WinSCP Windows Store Artifacts |
 | 2.16 | 2025-07-18 | Added More User.dat Windows Store UWP Artifacts - Network Share and WordPad |
+| 2.17 | 2025-07-20 | Added ApplicationAssociationToasts and More Office MRU Artifacts |
 
 # Documentation
 

--- a/BatchExamples/DFIRBatch.reb
+++ b/BatchExamples/DFIRBatch.reb
@@ -1,6 +1,6 @@
 Description: DFIR RECmd Batch File
 Author: Andrew Rathbun
-Version: 2.16
+Version: 2.17
 Id: 6e68cc0b-c945-428b-ab91-c02d91c877b8
 Keys:
 #
@@ -2065,6 +2065,27 @@ Keys:
         KeyPath: SOFTWARE\Microsoft\Office\*\*\User MRU\*\File MRU
         Recursive: false
         Comment: "Microsoft Office Recent Files, lower Item value (Value Name) = more recent"
+    -
+        Description: Microsoft Office MRU
+        HiveType: NTUSER
+        Category: User Activity
+        KeyPath: SOFTWARE\Microsoft\Office\*\*\File MRU
+        Recursive: false
+        Comment: "Microsoft Office Recent Files, lower Item value (Value Name) = more recent"
+    -
+        Description: Microsoft Office MRU
+        HiveType: NTUSER
+        Category: User Activity
+        KeyPath: SOFTWARE\Microsoft\Office\*\*\User MRU\*\Place MRU
+        Recursive: false
+        Comment: "Microsoft Office Recent Places"
+    -
+        Description: Microsoft Office MRU
+        HiveType: NTUSER
+        Category: User Activity
+        KeyPath: SOFTWARE\Microsoft\Office\*\*\Place MRU
+        Recursive: false
+        Comment: "Microsoft Office Recent Places"
 
 # OfficeMRU plugin - https://github.com/EricZimmerman/RegistryPlugins/tree/master/RegistryPlugin.OfficeMRU
 # https://www.eshlomo.us/windows-forensics-analysis-evidence/
@@ -3750,6 +3771,21 @@ Keys:
 # FileExts plugin - https://github.com/EricZimmerman/RegistryPlugins/tree/master/RegistryPlugin.FileExts
 # https://www.marshall.edu/forensics/files/Brewer-PosterFinal.pdf
 # https://digital-forensics.sans.org/summit-archives/2012/taking-registry-analysis-to-the-next-level.pdf
+
+    -
+        Description: ApplicationAssociationToasts
+        HiveType: NTUSER
+        Category: Installed Software
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts
+        Recursive: false
+        Comment: "Tracks programs associated with file extensions - Linked to Open With Dialog"
+    -
+        Description: ApplicationAssociationToasts
+        HiveType: User
+        Category: Installed Software
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts
+        Recursive: false
+        Comment: "Tracks programs associated with file extensions - Linked to Open With Dialog - Windows Store UWP"
 
 # Installed Software -> Add/Remove Program Entries
     -


### PR DESCRIPTION
## Description

Added ApplicationAssociationToasts which show up in both Windows Store Apps as well as normal Windows. It appears linked to the Open With Dialog as when I was testing with notepad and selected it to open an .evtx file the extension appeared in ApplicationAssociationToasts with a Notepad entry immediately after doing this. 

Additionally I added more Office MRU Artifacts tested with Office 2007 based on issue #98. I couldn't check Place MRU but based on the RegistryPlugin including this one too I put it in there. 

Currently in progress of testing older Office versions due to observing several older versions of Office still in production (Really should be using M365 Office now but *shrug*)



## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Batch file(s)
- [X] I have tested and validated the new Batch file(s) against test data and achieved the desired output
- [X] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory
- [X] I have set or updated the version of my Batch file(s)
- [X] I have made an attempt to document the artifacts within the Batch file(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
