### PR TITLE
Fix DateTime Format with SystemTime

### DIFF
--- a/RECmd/Program.cs
+++ b/RECmd/Program.cs
@@ -2350,8 +2350,8 @@ internal class Program
                             int int16_7 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 12 + index);
                             int int16_8 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 14 + index);
 
-                            var st = new DateTimeOffset(new DateTime(int16_1, int16_2, int16_4, int16_5, int16_6, int16_7, int16_8, DateTimeKind.Utc)).ToUniversalTime().ToString();
-                            rebOut.ValueData = st;
+                            var st = new DateTimeOffset(new DateTime(int16_1, int16_2, int16_4, int16_5, int16_6, int16_7, int16_8, DateTimeKind.Utc));
+                            rebOut.ValueData = st.ToUniversalTime().ToString(dt);
 
                         }
                         catch (Exception)
@@ -2416,8 +2416,8 @@ internal class Program
                         int int16_7 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 12 + index);
                         int int16_8 = (int)BitConverter.ToInt16(regVal.ValueDataRaw, 14 + index);
 
-                        var st = new DateTimeOffset(new DateTime(int16_1, int16_2, int16_4, int16_5, int16_6, int16_7, int16_8, DateTimeKind.Utc)).ToUniversalTime().ToString();
-                        rebOut.ValueData = st;
+                        var st = new DateTimeOffset(new DateTime(int16_1, int16_2, int16_4, int16_5, int16_6, int16_7, int16_8, DateTimeKind.Utc));
+                        rebOut.ValueData = st.ToUniversalTime().ToString(dt);
 
                     }
                     catch (Exception)


### PR DESCRIPTION
## Description

When I committed #65 I did not implement the DateTime Formatting bit like the other BinConvert formats. This fixes the issue as the following happened depending on the region set by the computer. This fix makes the behaviour consistent regardless of region. This is clean-up prep to adding more BinConvert formats

US Region:
<img width="414" height="75" alt="image" src="https://github.com/user-attachments/assets/460641ba-4dcc-4c59-b066-5ebf0c16705e" />

UK Region:
<img width="373" height="69" alt="image" src="https://github.com/user-attachments/assets/1f695487-1ee6-48e4-9745-96dc031c7daf" />

Fixed:
<img width="384" height="72" alt="image" src="https://github.com/user-attachments/assets/196d183e-352e-48aa-98a3-97b60385562b" />



## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

~~- [ ] I have generated a unique `GUID` for my Batch file(s)~~
~~- [ ] I have tested and validated the new Batch file(s) against test data and achieved the desired output~~
~~- [ ] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory~~
~~- [ ] I have set or updated the version of my Batch file(s)~~
~~- [ ] I have made an attempt to document the artifacts within the Batch file(s)~~
~~- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format~~

Thank you for your submission and for contributing to the DFIR community!
