### PR TITLE
Add DateTimeTicks and OLE Support to BinConvert

### DIFF
--- a/RECmd/Program.cs
+++ b/RECmd/Program.cs
@@ -2361,6 +2361,33 @@ internal class Program
                         }
 
 						break;
+                    case Key.BinConvert.DateTimeTicks:
+                        try
+                        {
+                            var dticks = BitConverter.ToInt64(regVal.ValueDataRaw, 0);
+                            var dtVal = new DateTime(dticks, DateTimeKind.Utc);
+                            rebOut.ValueData = dtVal.ToUniversalTime().ToString(dt);
+                        }
+                        catch (Exception)
+                        {
+                            Log.Warning("Error converting to DateTime.Ticks. Using bytes instead!");
+                            rebOut.ValueData = regVal.ValueData;
+                        }
+
+						break;
+                    case Key.BinConvert.OLE:
+                        try
+                        {
+                            var ft = DateTime.FromOADate(BitConverter.ToDouble(regVal.ValueDataRaw, 0));
+                            rebOut.ValueData = ft.ToString(dt);
+                        }
+                        catch (Exception)
+                        {
+                            Log.Warning("Error converting to OLE Automation Date OLE2.0. Using bytes instead!");
+                            rebOut.ValueData = regVal.ValueData;
+                        }
+
+                       break;
                     default:
                         rebOut.ValueData = regVal.ValueData;
                         break;
@@ -2423,6 +2450,36 @@ internal class Program
                     catch (Exception)
                     {
                         Log.Warning("Error converting to SYSTEMTIME. Using bytes instead!");
+                        rebOut.ValueData = regVal.ValueData;
+                    }
+
+                    break;
+
+                case Key.BinConvert.DateTimeTicks:
+                    try
+                    {
+                        var dticks = BitConverter.ToInt64(regVal.ValueDataRaw, 0);
+                        var dtVal = new DateTime(dticks, DateTimeKind.Utc);
+
+                        rebOut.ValueData = dtVal.ToUniversalTime().ToString(dt);
+                    }
+                    catch (Exception)
+                    {
+                        Log.Warning("Error converting to DateTime.Ticks. Using bytes instead!");
+                        rebOut.ValueData = regVal.ValueData;
+                    }
+
+                    break;
+
+                case Key.BinConvert.OLE:
+                    try
+                    {
+                        var ft = DateTime.FromOADate(BitConverter.ToDouble(regVal.ValueDataRaw, 0));
+                        rebOut.ValueData = ft.ToString(dt);
+                    }
+                    catch (Exception)
+                    {
+                        Log.Warning("Error converting to OLE Automation Date OLE2.0. Using bytes instead!");
                         rebOut.ValueData = regVal.ValueData;
                     }
 

--- a/RECmd/ReBatch.cs
+++ b/RECmd/ReBatch.cs
@@ -30,7 +30,9 @@ public class Key
         [Description("IPv4 address")] Ip = 2,
         [Description("DWord to Epoch")] Epoch = 3,
         [Description("Binary to SID")] Sid = 4,
-        [Description("128 bit Windows SYSTEMTIME")] Systemtime = 5
+        [Description("128 bit Windows SYSTEMTIME")] Systemtime = 5,
+        [Description("DateTime.Ticks")] DateTimeTicks = 6,
+        [Description("OLE Automation Date OLE2.0")] OLE = 7
     }
 
     public enum HiveType_


### PR DESCRIPTION
## Description

Adds DateTime.Ticks and Automation Date OLE2.0 Support with OLE support ported over from the Registry Explorer Data Interpreter.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

~~- [ ] I have generated a unique `GUID` for my Batch file(s)~~
~~- [ ] I have tested and validated the new Batch file(s) against test data and achieved the desired output~~
~~- [ ] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory~~
~~- [ ] I have set or updated the version of my Batch file(s)~~
~~- [ ] I have made an attempt to document the artifacts within the Batch file(s)~~
~~- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format~~

Thank you for your submission and for contributing to the DFIR community!
