### PR TITLE
Added ConsentStore Artifacts

### DIFF
--- a/BatchExamples/DFIRBatch.md
+++ b/BatchExamples/DFIRBatch.md
@@ -66,6 +66,7 @@ Example entry, please follow this format:
 | 2.15 | 2025-07-12 | Added Initial User.dat Windows Store UWP and WinSCP Windows Store Artifacts |
 | 2.16 | 2025-07-18 | Added More User.dat Windows Store UWP Artifacts - Network Share and WordPad |
 | 2.17 | 2025-07-20 | Added ApplicationAssociationToasts and More Office MRU Artifacts |
+| 2.18 | 2025-09-01 | Added ConsentStore Artifacts |
 
 # Documentation
 

--- a/BatchExamples/DFIRBatch.reb
+++ b/BatchExamples/DFIRBatch.reb
@@ -1,6 +1,6 @@
 Description: DFIR RECmd Batch File
 Author: Andrew Rathbun
-Version: 2.17
+Version: 2.18
 Id: 6e68cc0b-c945-428b-ab91-c02d91c877b8
 Keys:
 #
@@ -2463,6 +2463,112 @@ Keys:
 # https://docs.microsoft.com/en-us/troubleshoot/windows-server/remote/remove-entries-from-remote-desktop-connection-computer
 # https://www.cyberfox.blog/tag/rdp-mru/
 # https://ir3e.com/chapter-14-other-applications/
+
+# User Activity -> ConsentStore (Global)
+
+    -
+        Description: ConsentStore (Global)
+        HiveType: SOFTWARE
+        Category: User Activity
+        KeyPath: Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*
+        ValueName: Value
+        Recursive: true
+        Comment: "Displays Permissions Set For Applications to Access. Allow, Deny and Prompt"
+    -
+        Description: ConsentStore (Global)
+        HiveType: SOFTWARE
+        Category: User Activity
+        KeyPath: Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*\*
+        ValueName: LastUsedTimeStart
+        IncludeBinary: true
+        BinaryConvert: FILETIME
+        Recursive: false
+        Comment: "Displays timestamp of when a permission started being used with a given application"
+    -
+        Description: ConsentStore (Global)
+        HiveType: SOFTWARE
+        Category: User Activity
+        KeyPath: Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*\NonPackaged\*
+        ValueName: LastUsedTimeStart
+        IncludeBinary: true
+        BinaryConvert: FILETIME
+        Recursive: false
+        Comment: "Displays timestamp of when a permission started being used with a given application"
+    -
+        Description: ConsentStore (Global)
+        HiveType: SOFTWARE
+        Category: User Activity
+        KeyPath: Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*\*
+        ValueName: LastUsedTimeStop
+        IncludeBinary: true
+        BinaryConvert: FILETIME
+        Recursive: false
+        Comment: "Displays the timestamp of when a permission stopped being used with a given application"
+    -
+        Description: ConsentStore (Global)
+        HiveType: SOFTWARE
+        Category: User Activity
+        KeyPath: Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*\NonPackaged\*
+        ValueName: LastUsedTimeStop
+        IncludeBinary: true
+        BinaryConvert: FILETIME
+        Recursive: false
+        Comment: "Displays the timestamp of when a permission stopped being used with a given application"
+
+# https://www.cyberengage.org/post/registry-system-configiuration-tracking-microphone-and-camera-usage-in-windows-program-execution
+
+# User Activity -> ConsentStore (User)
+
+    -
+        Description: ConsentStore (User)
+        HiveType: NTUSER
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*
+        ValueName: Value
+        Recursive: true
+        Comment: "Displays Permissions Set For Applications to Access. Allow, Deny and Prompt"
+    -
+        Description: ConsentStore (User)
+        HiveType: NTUSER
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*\*
+        ValueName: LastUsedTimeStart
+        IncludeBinary: true
+        BinaryConvert: FILETIME
+        Recursive: false
+        Comment: "Displays timestamp of when a permission started being used with a given application"
+    -
+        Description: ConsentStore (User)
+        HiveType: NTUSER
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*\NonPackaged\*
+        ValueName: LastUsedTimeStart
+        IncludeBinary: true
+        BinaryConvert: FILETIME
+        Recursive: false
+        Comment: "Displays timestamp of when a permission started being used with a given application"
+    -
+        Description: ConsentStore (User)
+        HiveType: NTUSER
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*\*
+        ValueName: LastUsedTimeStop
+        IncludeBinary: true
+        BinaryConvert: FILETIME
+        Recursive: false
+        Comment: "Displays the timestamp of when a permission stopped being used with a given application"
+    -
+        Description: ConsentStore (User)
+        HiveType: NTUSER
+        Category: User Activity
+        KeyPath: Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\*\NonPackaged\*
+        ValueName: LastUsedTimeStop
+        IncludeBinary: true
+        BinaryConvert: FILETIME
+        Recursive: false
+        Comment: "Displays the timestamp of when a permission stopped being used with a given application"
+
+# https://www.cyberengage.org/post/registry-system-configiuration-tracking-microphone-and-camera-usage-in-windows-program-execution
 
 # --------------------
 # AUTORUNS


### PR DESCRIPTION
## Description

This adds ConsentStore artifacts for both NTUser as well as HKLM/Software. This displays permissions set for applications to access such as webcam, microphone and geolocation as well as the length of time applications utilised the permissions for. This will be useful as evidence of application usage.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Batch file(s)
- [X] I have tested and validated the new Batch file(s) against test data and achieved the desired output
- [X] I have placed the Batch file(s) within the `.\RECmd\BatchExamples` directory
- [X] I have set or updated the version of my Batch file(s)
- [X] I have made an attempt to document the artifacts within the Batch file(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.guide)/[Template](https://github.com/EricZimmerman/RECmd/blob/master/BatchExamples/!RECmdBatch.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
